### PR TITLE
Add ghostty terminal theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Warp](warp/README.md) - A Warp terminal theme
 - [Zed](zed/README.md) - A Zed editor theme
 - [JetBrains](jetbrains/README.md) - A theme for all JetBrains IDEs (IntelliJ, PyCharm, WebStorm, etc.)
+- [Ghostty](ghostty/README.md) - A Ghostty terminal theme
 
 ## About
 
@@ -47,6 +48,62 @@ This is a Work in Progress (WIP). Like jazz itself, we believe in constant evolu
 ## The Name
 
 "Guttenbergovitz" merges Gutenberg's printing heritage with Eastern European craftsmanship tradition (-ovitz), reflecting our commitment to both historical respect and modern utility.
+
+## Ghostty Terminal Theme
+
+### Installation
+
+#### Manual Installation
+
+1. Create the themes directory for Ghostty (if it doesn't exist):
+```bash
+mkdir -p ~/.config/ghostty/themes
+```
+
+2. Download the theme file:
+```bash
+curl -o ~/.config/ghostty/themes/guttenbergovitz.conf https://raw.githubusercontent.com/guttenbergovitz/guttenbergovitz-theme/main/ghostty/guttenbergovitz.conf
+```
+
+#### Manual Installation (Alternative)
+
+1. Clone this repository:
+```bash
+git clone https://github.com/guttenbergovitz/guttenbergovitz-theme.git
+```
+
+2. Create the themes directory for Ghostty:
+```bash
+mkdir -p ~/.config/ghostty/themes
+```
+
+3. Copy the theme file:
+```bash
+cp guttenbergovitz-theme/ghostty/guttenbergovitz.conf ~/.config/ghostty/themes/
+```
+
+### Activation
+
+To use the theme, you need to specify it in your Ghostty config file (`~/.config/ghostty/config.conf`):
+
+```conf
+include themes/guttenbergovitz.conf
+```
+
+## Color Palette
+
+The theme uses a carefully curated palette inspired by vintage printing and jazz aesthetics:
+
+- Background: `#232326`
+- Foreground: `#d4be98`
+- Black: `#1d1d20`
+- Red: `#a96b69`
+- Green: `#89a87d`
+- Yellow: `#d6b986`
+- Blue: `#d79969`
+- Magenta: `#a96b69`
+- Cyan: `#89a87d`
+- White: `#d4be98`
 
 ---
 

--- a/ghostty/guttenbergovitz.conf
+++ b/ghostty/guttenbergovitz.conf
@@ -1,0 +1,38 @@
+# Guttenbergovitz theme for Ghostty terminal
+# Inspired by vintage printing and jazz aesthetics
+
+# Base colors
+foreground #d4be98
+background #232326
+
+# Black
+color0 #1d1d20
+color8 #7c7c7c
+
+# Red
+color1 #a96b69
+color9 #a96b69
+
+# Green
+color2 #89a87d
+color10 #89a87d
+
+# Yellow
+color3 #d6b986
+color11 #d6b986
+
+# Blue
+color4 #d79969
+color12 #d79969
+
+# Magenta
+color5 #a96b69
+color13 #a96b69
+
+# Cyan
+color6 #89a87d
+color14 #89a87d
+
+# White
+color7 #d4be98
+color15 #d4be98


### PR DESCRIPTION
Add a new `ghostty` terminal theme and update the main `README.md` with relevant information.

* **New Theme File**
  - Create `ghostty/guttenbergovitz.conf` with the same color palette as other terminal themes.
  - Set foreground color to `#d4be98` and background color to `#232326`.
  - Define the color palette for black, red, green, yellow, blue, magenta, cyan, and white.

* **README.md Updates**
  - Add a new section for the `ghostty` terminal theme.
  - Include installation instructions for the `ghostty` terminal theme.
  - Mention the `ghostty` terminal theme in the list of available themes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/guttenbergovitz/guttenbergovitz-theme/pull/3?shareId=9c8ec13c-2e2c-4054-8bd2-dd13703190de).