### PR TITLE
Fix ghostty theme colors to match VS Code theme

### DIFF
--- a/ghostty/guttenbergovitz
+++ b/ghostty/guttenbergovitz
@@ -1,26 +1,22 @@
-background = EFEBD4
-foreground = 5C6A72
-cursor-color = BDC3AF
-selection-background = EAEDC8
-selection-foreground = 5C6A72
+background = 232326
+foreground = d4be98
+cursor-color = d4be98
+selection-background = 3a3a3d
+selection-foreground = 232326
 
-palette = 0=#EFEBD4
-
-palette = 1=#F85552
-palette = 2=#8DA101
-palette = 3=#DFA000
-palette = 4=#8DA101
-palette = 5=#3A94C5
-palette = 6=#35A77C
-
-palette = 7=#DF69BA
-palette = 8=#FDF6E3
-
-palette = 9=#EAEDC8
-palette = 10=#F0F1D2
-palette = 11=#FAEDCD
-palette = 12=#E9F0E9
-palette = 13=#FBE3DA
-palette = 14=#35A77C
-
-palette = 15=#5C6A72
+palette = 0=#1d1d20
+palette = 1=#a96b69
+palette = 2=#89a87d
+palette = 3=#d6b986
+palette = 4=#d79969
+palette = 5=#a96b69
+palette = 6=#89a87d
+palette = 7=#d4be98
+palette = 8=#7c7c7c
+palette = 9=#a96b69
+palette = 10=#89a87d
+palette = 11=#d6b986
+palette = 12=#d79969
+palette = 13=#a96b69
+palette = 14=#89a87d
+palette = 15=#d4be98


### PR DESCRIPTION
Update the color palette and theme settings in `ghostty/guttenbergovitz` to match the VS Code theme.

* **Background, Foreground, and Cursor Colors**
  - Change background color to `#232326`
  - Change foreground color to `#d4be98`
  - Change cursor color to `#d4be98`

* **Selection Colors**
  - Change selection background color to `#3a3a3d`
  - Change selection foreground color to `#232326`

* **Palette Colors**
  - Update palette colors to match the VS Code theme, including:
    - `0=#1d1d20`
    - `1=#a96b69`
    - `2=#89a87d`
    - `3=#d6b986`
    - `4=#d79969`
    - `5=#a96b69`
    - `6=#89a87d`
    - `7=#d4be98`
    - `8=#7c7c7c`
    - `9=#a96b69`
    - `10=#89a87d`
    - `11=#d6b986`
    - `12=#d79969`
    - `13=#a96b69`
    - `14=#89a87d`
    - `15=#d4be98`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/guttenbergovitz/guttenbergovitz-theme/pull/10?shareId=5441afc1-b6b4-47dc-bb3b-08cb81a6d82d).